### PR TITLE
Filtration based on URL structure + relevant tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,4 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+*.csv

--- a/newsfeedback/main.py
+++ b/newsfeedback/main.py
@@ -1,9 +1,14 @@
-import click
+import trafilatura, click, re
 import pandas as pd
-import trafilatura, re
+import time
 from trafilatura import feeds
 from loguru import logger as log
-
+from bs4 import BeautifulSoup
+from selenium import webdriver
+from selenium.webdriver.firefox.service import Service as FirefoxService
+from webdriver_manager.firefox import GeckoDriverManager
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.wait import WebDriverWait
 
 @click.command()
 @click.argument("name", type=str)
@@ -30,9 +35,11 @@ def cli_implementation(name: str) -> None:
     """
     return f"Hello {name}!"
 
+### Best case functions
+
 def get_article_urls_best_case(homepage_url):
     """ Retrieves article URLs from a given homepage trafilatura's find_feed_urls function.
-    Prints out the number of articles found if at least one has been retrieved.
+    Prints out the number of articles found if at least one has been retrieved. 
     """
     article_url_list = feeds.find_feed_urls(homepage_url)
     if len(article_url_list) != 0:
@@ -58,7 +65,7 @@ def get_article_metadata_best_case(article_url, metadata_wanted):
     
 def get_article_urls_and_metadata_best_case(homepage_url, metadata_wanted):
     """ Combines get_article_urls_best_case() and get_article_metadata_best_case() for a seamless 
-    seqence of actions. The results are stored in a dataframe.
+    sequence of actions. The results are stored in a dataframe.
     """
     get_article_urls_best_case(homepage_url)
     article_url_list = get_article_urls_best_case.article_url_list
@@ -70,6 +77,146 @@ def get_article_urls_and_metadata_best_case(homepage_url, metadata_wanted):
     df = pd.DataFrame.from_dict(article_list)
     get_article_urls_and_metadata_best_case.df = df
     return get_article_urls_and_metadata_best_case.df
-        
+
+### Worst case functions 
+
+def get_article_urls_worst_case(homepage_url):
+    """ Retrieves URLs from a given homepage through beautiful soup, by getting all href attributes of
+    an a tag. Prints out the number of articles found if at least one has been retrieved. 
+    """
+    article_list = feeds.find_feed_urls(homepage_url)
+    article_url_list = []
+    downloaded = trafilatura.fetch_url(homepage_url)
+    soup = BeautifulSoup(downloaded, 'html.parser')
+    for a in soup.find_all('a'):
+        href = a.get('href')
+        http_check = re.search(r'(http)', f'{href}')
+        if href != None:
+            if http_check == None:
+                http_url = f"{homepage_url}" + f"{href}"
+                double_slash_check = re.search(r"(?<!https:)(//)", http_url)
+                if double_slash_check:
+                    http_url = re.sub(r"(?<!https:)(//)", r"/", http_url)
+                double_de_check = re.search(r"/de/de/", http_url)
+                if double_de_check:
+                    http_url = re.sub(r"/de/de/", r"/de/", http_url)
+                article_url_list.append(http_url)
+            else:
+                homepage_de = re.search(r'(https://www\..+?\.\w{2,3}/de/)', homepage_url)
+                if homepage_de:
+                    homepage_split = homepage_de.group(0)
+                else:
+                    homepage_split = re.search(r'(https://www\..+?\.\w{2,3})', homepage_url).group(0)
+                homepage_check = re.search(fr'{homepage_split}/.+', href)
+                if homepage_check:
+                    article_url_list.append(href)
+    article_url_list = list(dict.fromkeys(article_url_list)) # refactor these!
+    article_url_list = list(filter(lambda item: item is not None, article_url_list))
+    print(f'{len(article_url_list)} links have been found.\r')
+    get_article_urls_worst_case.article_url_list = article_url_list
+    return get_article_urls_worst_case.article_url_list
+
+def get_article_metadata_worst_case(article_url, metadata_wanted):
+    """ Extracts predefined (metadata_wanted) metadata from the given article url. 
+    Returns an empty dict if no metadata is found.
+    """
+    downloaded = trafilatura.fetch_url(article_url)
+    if downloaded != None:
+        metadata = trafilatura.bare_extraction(downloaded, only_with_metadata=True, include_links=True)
+        if metadata != None:
+            dict_keys = list(metadata.keys()) # look into refactoring the following bit of code at some point
+            dict_keys_to_pop = [key for key in dict_keys if key not in metadata_wanted]
+            for key in dict_keys_to_pop: 
+                metadata.pop(key, None)
+        else:
+            metadata = {}
+    else:  
+        metadata = {}
+    #metadata = {metadata_key: metadata_value for metadata_key, metadata_value in metadata.items() if metadata_key and metadata_value}
+    get_article_metadata_worst_case.metadata = metadata
+    return get_article_metadata_worst_case.metadata
+
+def get_article_urls_and_metadata_worst_case(homepage_url, metadata_wanted): # might be a bit slow
+    """ Combines get_article_urls_wost_case() and get_article_metadata_worst_case() for a seamless 
+    sequence of actions. The results are stored in a dataframe.
+    """
+    get_article_urls_worst_case(homepage_url)
+    article_url_list = get_article_urls_worst_case.article_url_list
+    article_list = []
+    for article_url in article_url_list:
+        if article_url != None:
+            print(article_url)
+            get_article_metadata_worst_case(article_url, metadata_wanted)
+            metadata =  get_article_metadata_worst_case.metadata
+            if len(metadata) != 0: # nested a bit too deep for my tastes, will refactor eventually
+                article_list.append(metadata)
+    print(f'{homepage_url}: {len(article_list)} articles have been found.\r')
+    df = pd.DataFrame.from_dict(article_list)
+    print(df)
+    get_article_urls_and_metadata_worst_case.df = df
+    return get_article_urls_and_metadata_worst_case.df
+
+### Filter-related functions
+
+def filter_urls(article_url_list):
+    """ Filters out non-viable article URLs through a whitelist.
+    Criteria: url ends in word character (-> not a / )"""
+    article_url_list_clean = []
+    for article in article_url_list:
+        viable_article = re.search(r"((/(\w+-)+\w+-\w+(\.html)?)|/-/\w+)", article)
+        if viable_article:
+            article_url_list_clean.append(article)
+    print(f'Removed {(len(article_url_list)-len(article_url_list_clean))} superfluous URLs.')
+    filter_urls.article_url_list_clean = article_url_list_clean
+    return filter_urls.article_url_list_clean
+
+def get_filtered_article_urls_and_metadata_best_case(homepage_url, metadata_wanted):
+    """ Combines get_article_urls_best_case(), filter_urls() and get_article_metadata_best_case()
+    for a seamless sequence of actions. The results are stored in a dataframe.
+    """
+    get_article_urls_best_case(homepage_url)
+    article_url_list = get_article_urls_best_case.article_url_list
+    article_url_list_clean = filter_urls(article_url_list)
+    article_list = []
+    if len(article_url_list_clean) != 0:
+        for article_url in article_url_list_clean:
+            get_article_metadata_best_case(article_url, metadata_wanted)
+            metadata =  get_article_metadata_best_case.metadata
+            article_list.append(metadata)
+    df = pd.DataFrame.from_dict(article_list)
+    get_article_urls_and_metadata_best_case.df = df
+    return get_article_urls_and_metadata_best_case.df
+    
+def get_filtered_article_urls_and_metadata_worst_case(homepage_url, metadata_wanted):
+    """ Combines get_article_urls_wost_case(), filter_urls() and get_article_metadata_worst_case() 
+    for a seamless sequence of actions. The results are stored in a dataframe.
+    """
+    get_article_urls_worst_case(homepage_url)
+    article_url_list = get_article_urls_worst_case.article_url_list
+    article_url_list_clean = filter_urls(article_url_list)
+    article_list = []
+    for article_url in article_url_list_clean:
+        if article_url != None:
+            get_article_metadata_worst_case(article_url, metadata_wanted)
+            metadata =  get_article_metadata_worst_case.metadata
+            if len(metadata) != 0: # nested a bit too deep for my tastes, will refactor eventually
+                article_list.append(metadata)
+    print(f'{homepage_url}: {len(article_list)} articles have been found.\r')
+    df = pd.DataFrame.from_dict(article_list)
+    print(df)
+    get_article_urls_and_metadata_worst_case.df = df
+    return get_article_urls_and_metadata_worst_case.df
+
+def export_dataframe(df, homepage_url, output_folder):
+    """ Exports a given dataframe, naming it based on datetime and homepage url.
+    """
+    df_name = re.search(r"\..+?\.",f"{homepage_url}").group(0)
+    df_name = df_name.replace(".","") 
+    timestr = time.strftime(r"%Y%m%d-%H%M")
+    df_path = f"{output_folder}/{timestr}-"+f"{df_name}"+f".csv"
+    df.to_csv(df_path, index=False, mode='a')
+    export_dataframe.df_path = df_path
+    return export_dataframe.df_path
+
 if __name__ == "main":
     cli()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,12 +1,15 @@
 """ Test suite for newsfeedback.main
 """
-
 import pytest
+import pandas as pd
+import time
+from click.testing import CliRunner
+from newsfeedback.main import get_article_urls_best_case, get_article_metadata_best_case, get_article_urls_and_metadata_best_case
+from newsfeedback.main import get_article_urls_worst_case, get_article_metadata_worst_case, get_article_urls_and_metadata_worst_case
+from newsfeedback.main import  filter_urls, get_filtered_article_urls_and_metadata_best_case, get_filtered_article_urls_and_metadata_worst_case, export_dataframe
 
-from newsfeedback.main import cli_implementation, get_article_urls_best_case, get_article_metadata_best_case, get_article_urls_and_metadata_best_case
-   
 class TestBestCasePipeline(object):
-    def test_GetArticleURLs_BestCase_GoodURL(self):
+    def test_get_article_urls_bestcase_goodurl(self):
         """ Asserts whether article URLs have successfully been extracted from a "best case" homepage.
         """
         homepage_url = "https://www.spiegel.de/"
@@ -17,7 +20,7 @@ class TestBestCasePipeline(object):
                    "to {1}".format(len(actual),not_expected))
         assert len(actual) != not_expected, message
         
-    def test_GetArticleURLs_BestCase_BadURL(self):
+    def test_get_article_urls_bestcase_badurl(self):
         """ Asserts whether article URLs fail to be extracted from a "worst case" homepage.
         """
         homepage_url = "https://www.badische-zeitung.de/"
@@ -27,8 +30,9 @@ class TestBestCasePipeline(object):
                    "returned {0} instead "
                    "of {1}".format(len(actual),expected))
         assert len(actual) == expected, message
+
      
-    def test_GetArticleMetadata_TitleDateURLDescription_BestCase_GoodURL(self):
+    def test_get_article_metadata_title_date_url_description_bestcase_goodurl(self):
         """ Asserts whether the desired metadata (in this case: Title, Date, URL, Description) 
         can be extracted from an article
         """
@@ -41,7 +45,7 @@ class TestBestCasePipeline(object):
                    "to {1}".format(len(actual),not_expected))
         assert len(actual) != not_expected, message
        
-    def test_GetArticleMetadata_TitleDateURLDescription_BestCase_BadURL(self):        
+    def test_get_article_metadata_title_date_url_description_bestcase_badurl(self):        
         """ Asserts whether the desired metadata (in this case: Title, Date, URL, Description) 
         fail to be extracted from a webpage that is not an article
         """
@@ -54,7 +58,7 @@ class TestBestCasePipeline(object):
                    "of {1}".format(len(actual),expected))
         assert len(actual) == expected, message
         
-    def test_GetArticleURLAndMetadata_TitleDateURLDescription_BestCase_GoodURL(self):
+    def test_get_article_url_and_metadata_title_date_url_description_bestcase_goodurl(self):
         """ Asserts whether the desired metadata (in this case: Title, Date, URL, Description) 
         can be extracted from an article whose URL was previously extracted from a "best case" homepage
         """
@@ -67,9 +71,10 @@ class TestBestCasePipeline(object):
                    "to {1}".format(len(actual),not_expected))
         assert len(actual) != not_expected, message        
         
-    def test_GetArticleURLAndMetadata_TitleDateURLDescription_BestCase_BadURL(self):
+    def test_get_article_url_and_metadata_title_date_url_description_bestcase_badurl(self):
         """ Asserts whether the desired metadata (in this case: Title, Date, URL, Description) 
-        fail to be extracted from an article whose URL failed to be extracted from a "worst case" homepage
+        fail to be extracted from a URL that is not an article and thus a "bad URL" within the
+        "best case" pipeline.
         """
         homepage_url = "https://leibniz-hbi.de/en"
         metadata_wanted = ['title', 'date', 'url', 'description']
@@ -77,6 +82,163 @@ class TestBestCasePipeline(object):
         expected = 0
         message = ("get_article_metadata_best_case(article_url, metadata_wanted) "
                    "returned {0}, instead "
+                   "of {1}".format(actual.shape[0],expected))
+        assert actual.shape[0] == expected, message     
+
+class TestFilterPipeline(object):
+    def test_filter_article_urls_bestcase_goodurl(self):
+        """ Asserts whether article URLs extracted with
+        trafilatura remain following the filtering process.
+        """
+        homepage_url = "https://www.spiegel.de/"
+        get_article_urls_best_case(homepage_url)
+        article_url_list = get_article_urls_best_case.article_url_list
+        actual = filter_urls(article_url_list)
+        not_expected = 0 
+        message = ("filter_urls(article_url_list) "
+                   "returned {0}, which is identical "
+                   "to {1}".format(len(actual),not_expected))
+        assert len(actual) != not_expected, message
+
+    def test_filter_article_urls_bestcase_badurl(self):
+        """ Asserts whether article URLs continue to fail to be extracted and subsequently
+        fail to be filtered when using a "bad" URL.
+        """
+        homepage_url = "https://www.badische-zeitung.de/"
+        get_article_urls_best_case(homepage_url)
+        article_url_list = get_article_urls_best_case.article_url_list
+        actual = filter_urls(article_url_list)
+        expected = 0 
+        message = ("filter_urls(article_url_list) "
+                   "returned {0} instead "
                    "of {1}".format(len(actual),expected))
-        assert len(actual) == expected, message        
+        assert len(actual) == expected, message    
+
+    def test_filter_article_urls_worstcase_goodurl(self):
+        """ Asserts whether article URLs extracted with
+        beautifulsoup remain following the filtering process.
+        """
+        homepage_url = "https://www.badische-zeitung.de/"
+        get_article_urls_worst_case(homepage_url)
+        article_url_list = get_article_urls_worst_case.article_url_list
+        actual = filter_urls(article_url_list)
+        not_expected = 0 
+        message = ("filter_urls(article_url_list) "
+                   "returned {0}, which is identical "
+                   "to {1}".format(len(actual),not_expected))
+        assert len(actual) != not_expected, message
+
+    def test_filter_get_article_url_and_metadata_title_date_url_description_bestcase_goodurl(self):
+        """ Asserts whether the desired metadata (in this case: Title, Date, URL, Description) 
+        can be extracted from a "best case" homepage article which remained after the filtering process.
+        """
+        homepage_url = "https://www.spiegel.de/"
+        metadata_wanted = ['title', 'date', 'url', 'description']
+        actual = get_filtered_article_urls_and_metadata_best_case(homepage_url, metadata_wanted)
+        not_expected = 0
+        message = ("get_filtered_article_urls_and_metadata_best_case(article_url, metadata_wanted) "
+                   "returned {0}, which is identical "
+                   "to {1}".format(actual.shape[0],not_expected))
+        assert actual.shape[0] != not_expected, message        
         
+    def test_filter_get_article_url_and_metadata_title_date_url_description_bestcase_badurl(self):
+        """ Asserts whether the desired metadata (in this case: Title, Date, URL, Description) 
+        fail to be extracted from a URL that is not an article. It is thus a "bad URL" within the
+        "best case" filtered URL pipeline.
+        """
+        homepage_url = "https://www.badische-zeitung.de/"
+        metadata_wanted = ['title', 'date', 'url', 'description']
+        actual = get_filtered_article_urls_and_metadata_best_case(homepage_url, metadata_wanted)
+        expected = 0
+        message = ("get_filtered_article_urls_and_metadata_best_case(article_url, metadata_wanted) "
+                   "returned {0}, instead "
+                   "of {1}".format(actual.shape[0],expected))
+        assert actual.shape[0] == expected, message     
+
+    def test_filter_get_article_url_and_metadata_title_date_url_description_worstcase_goodurl(self):
+        """ Asserts whether the article URLs and desired metadata (in this case: Title, Date, URL, Description) 
+        can be extracted from "worst case" homepage articles which remained after the filtering process.
+        """
+        homepage_url = "https://www.badische-zeitung.de/"
+        metadata_wanted = ['title', 'date', 'url', 'description']
+        actual = get_filtered_article_urls_and_metadata_worst_case(homepage_url, metadata_wanted)
+        not_expected = 0
+        message = ("get_filtered_article_urls_and_metadata_worst_case(article_url, metadata_wanted) "
+                   "returned {0}, which is identical "
+                   "to {1}".format(actual.shape[0],not_expected))
+        assert actual.shape[0] != not_expected, message          
+
+class TestWorstCasePipeline(object):
+    def test_get_article_urls_worstcase_goodurl(self):
+        """ Asserts whether article URLs have successfully been extracted from a "worst case" homepage
+        using beautifulsoup.
+        """
+        homepage_url = "https://www.badische-zeitung.de/"
+        actual = get_article_urls_worst_case(homepage_url)
+        not_expected = 0
+        message = ("get_article_urls_worst_case(homepage_url) "
+                   "returned {0}, which is identical "
+                   "to {1}".format(len(actual),not_expected))
+        assert len(actual) != not_expected, message
+
+    ### would be good to find an URL without any a hrefs to test the opposing case
+
+    def test_get_article_metadata_title_date_url_description_worstcase_goodurl(self):
+        """ Asserts whether the desired metadata (in this case: Title, Date, URL, Description) 
+        can be extracted from an article URL that was retrieved from the homepage whose articles
+        can only be extracted with beautifulsoup.
+        """
+        article_url = "https://www.badische-zeitung.de/unwetterwarnung-aufgehoben-aber-schnee-und-eis-sollen-ueber-nacht-zurueckkehren"
+        metadata_wanted = ['title', 'date', 'url', 'description']
+        actual = get_article_metadata_worst_case(article_url, metadata_wanted)
+        not_expected = 0
+        message = ("get_article_metadata_worst_case(article_url, metadata_wanted) "
+                   "returned {0}, which is identical "
+                   "to {1}".format(len(actual),not_expected))
+        assert len(actual) != not_expected, message
+
+    def test_get_article_url_and_metadata_title_date_url_description_worstcase_goodurl(self):
+        """ Asserts whether the article URLs and desired metadata (in this case: Title, Date, URL, Description) 
+        can be extracted from a "worst case" homepage.
+        """
+        homepage_url = "https://www.badische-zeitung.de/"
+        metadata_wanted = ['title', 'date', 'url', 'description']
+        actual = get_article_urls_and_metadata_worst_case(homepage_url, metadata_wanted)
+        not_expected = 0
+        message = ("get_article_urls_and_metadata_worst_case(article_url, metadata_wanted) "
+                   "returned {0}, which is identical "
+                   "to {1}".format(actual.shape[0],not_expected))
+        assert actual.shape[0] != not_expected, message          
+
+class TestExportCSV(object):
+    def test_export_bestcase_goodurl(self):
+        """ Asserts whether the dataframe put into the export function and the final
+        CSV are the same length. The data for the dataframe has gone through the best case pipeline.
+        """
+        homepage_url = "https://www.spiegel.de/"
+        metadata_wanted = ['title', 'date', 'url', 'description']
+        output_folder = "newsfeedback/output"
+        df = get_filtered_article_urls_and_metadata_best_case(homepage_url, metadata_wanted)
+        export_dataframe(df, homepage_url, output_folder)
+        df_path = export_dataframe.df_path
+        df_from_file = pd.read_csv(df_path)
+        message = ("The number of entries in the original dataframe ({0}) "
+                   "is not identical to the number of entries "
+                   "in the exported dataframe ({1}).".format(df.shape[0],df_from_file.shape[0]))                
+        assert df.shape[0] == df_from_file.shape[0], message
+    
+    def test_export_worstcase_goodurl(self):
+        """ Asserts whether the dataframe put into the export function and the final
+        CSV are the same length. The data for the dataframe has gone through the worst case pipeline.
+        """
+        homepage_url = "https://www.badische-zeitung.de/"
+        metadata_wanted = ['title', 'date', 'url', 'description']
+        output_folder = "newsfeedback/output"
+        df = get_filtered_article_urls_and_metadata_worst_case(homepage_url, metadata_wanted)
+        export_dataframe(df, homepage_url, output_folder)
+        df_path = export_dataframe.df_path
+        df_from_file = pd.read_csv(df_path)
+        message = ("The number of entries in the original dataframe ({0}) "
+                   "is not identical to the number of entries "
+                   "in the exported dataframe ({1}).".format(df.shape[0],df_from_file.shape[0]))                
+        assert df.shape[0] == df_from_file.shape[0], message


### PR DESCRIPTION
Implemented a post-URL-extraction filtration system based on a regex whitelist and functional within both pipelines. URLs without backslashes at the end and at least three words separated by hyphens are considered valid article URLs. 
The necessary tests have also been implemented, as well as an export function that saves the dataframes as CSVs with URL and datetime in the name.