### PR TITLE
Successful bypass of pur abo barrier

### DIFF
--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -2,11 +2,10 @@
 """
 import pytest
 import pandas as pd
-import time
-from click.testing import CliRunner
 from newsfeedback.main import get_article_urls_best_case, get_article_metadata_best_case, get_article_urls_and_metadata_best_case
 from newsfeedback.main import get_article_urls_worst_case, get_article_metadata_worst_case, get_article_urls_and_metadata_worst_case
-from newsfeedback.main import  filter_urls, get_filtered_article_urls_and_metadata_best_case, get_filtered_article_urls_and_metadata_worst_case, export_dataframe
+from newsfeedback.main import filter_urls, get_filtered_article_urls_and_metadata_best_case, get_filtered_article_urls_and_metadata_worst_case, export_dataframe
+from newsfeedback.main import accept_pur_abo
 
 class TestBestCasePipeline(object):
     def test_get_article_urls_bestcase_goodurl(self):
@@ -49,7 +48,7 @@ class TestBestCasePipeline(object):
         """ Asserts whether the desired metadata (in this case: Title, Date, URL, Description) 
         fail to be extracted from a webpage that is not an article
         """
-        article_url = "https://leibniz-hbi.de/en"
+        article_url = "https://hans-bredow-institut.de/"
         metadata_wanted = ['title', 'date', 'url', 'description']
         actual = get_article_metadata_best_case(article_url, metadata_wanted)
         expected = 0
@@ -76,7 +75,7 @@ class TestBestCasePipeline(object):
         fail to be extracted from a URL that is not an article and thus a "bad URL" within the
         "best case" pipeline.
         """
-        homepage_url = "https://leibniz-hbi.de/en"
+        homepage_url = "https://smo-wiki.leibniz-hbi.de/"
         metadata_wanted = ['title', 'date', 'url', 'description']
         actual = get_article_urls_and_metadata_best_case(homepage_url, metadata_wanted)
         expected = 0
@@ -209,6 +208,32 @@ class TestWorstCasePipeline(object):
                    "returned {0}, which is identical "
                    "to {1}".format(actual.shape[0],not_expected))
         assert actual.shape[0] != not_expected, message          
+
+class TestWebsiteSpecificFunctions(object):
+    def test_accept_pur_abo_consent_button(self):
+        """ Asserts whether the elements (iframe, button and homepage title) were found by printing
+        out the page source of the homepage.
+        """
+        homepage_url = "https://www.zeit.de/"
+        class_name = "sp_choice_type_11" # full class names: 'message-component message-button no-children focusable sp_choice_type_11'
+        actual = accept_pur_abo(homepage_url, class_name)
+        error_message = 'Element could not be found, connection timed out.'
+        message = ("accept_pur_abo(homepage_url, class_name) "
+                  "returned {0}, which is an undesired error message.".format(actual, error_message))
+        assert actual != error_message, message    
+        
+    def test_accept_pur_abo_subscription_button(self):
+        """ Checks that a TimeOutException has occurred by asserting whether the
+        desired error message has been printed.
+        """
+        homepage_url = "https://www.zeit.de/"
+        class_name = "js-forward-link-purabo" # full class names: 'option__button option__button--pur js-forward-link-purabo'
+        actual = accept_pur_abo(homepage_url, class_name)
+        error_message = 'Element could not be found, connection timed out.'
+        message = ("accept_pur_abo(homepage_url, class_name) did not return "
+                   "the desired error message, but instead"
+                   "{0}".format(actual, error_message))
+        assert actual == error_message, message   
 
 class TestExportCSV(object):
     def test_export_bestcase_goodurl(self):


### PR DESCRIPTION
All tests are running successfully. Consent button to proceed without the pur abo is found (via iframe), clicked and the driver waits until the homepage is loaded before closing. This sets the stage for connection of this function with the extraction pipelines. Compatibility with the GeckoDriver currently nonexistent, might be nice to have in the future.