### PR TITLE
First general update two years on: goodbye purabo, hello new issues

### DIFF
--- a/newsfeedback/defaults/default_homepage_config.yaml
+++ b/newsfeedback/defaults/default_homepage_config.yaml
@@ -1,6 +1,6 @@
 'https://www.spiegel.de/':
-  pipeline: 'trafilatura'
-  filter: 'off'
+  pipeline: 'beautifulsoup'
+  filter: 'on'
 
 'https://www.badische-zeitung.de/':
   pipeline: 'beautifulsoup'
@@ -19,8 +19,8 @@
   filter: 'on'
 
 'https://www.handelsblatt.com/':
-  pipeline: 'trafilatura'
-  filter: 'off'
+  pipeline: 'beautifulsoup'
+  filter: 'on'
 
 'https://www.n-tv.de/':
   pipeline: 'trafilatura'
@@ -39,7 +39,7 @@
   filter: 'on'
 
 'https://www.sueddeutsche.de/':
-  pipeline: 'trafilatura'
+  pipeline: 'beautifulsoup'
   filter: 'off'
 
 'https://www.t-online.de/':
@@ -67,5 +67,5 @@
   filter: 'on'
 
 'https://www.zeit.de/':
-  pipeline: 'purabo'
-  filter: 'on'
+  pipeline: 'trafilatura'
+  filter: 'off'

--- a/newsfeedback/main.py
+++ b/newsfeedback/main.py
@@ -11,7 +11,6 @@ from selenium.webdriver.common.by import By
 from selenium.webdriver.support.wait import WebDriverWait
 from selenium.common.exceptions import TimeoutException
 
-#log.add(sys.stderr, format = "<red>[{level}]</red> : <green>{message}</green> @ {time}", colorize=True, level="ERROR")
 
 @click.group()
 def cli():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ selenium = "^4.8.0"
 webdriver-manager = "^3.8.5"
 schedule = "^1.1.0"
 pytest-html = "^3.2.0"
-pandas = "^1.5.3"
+pandas = "^2.2.0"
 
 [tool.poetry.group.dev.dependencies]
 pytest = "*"


### PR DESCRIPTION
Major changes: pur abo pipeline was dropped, as zeit online is now covered by trafilatura. Adjustments have been made to accomodate Spiegel blocking trafilatura and handelsblatt needing javascript. Pages and their associates pipelines continue to be in flux and updated accordingly. It's pretty slow all in all - shifting from selenium to requests for anything that can handle it will help with that.